### PR TITLE
Test other model endpoints

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,5 +1,4 @@
 README.md
-Dockerfile
 .git/
 .idea/
 tests/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,13 @@
 language: python
 python:
-- 3.6
+  - 3.6
 services:
-- docker
+  - docker
 install:
-- docker build -t max-review-text-generator .
-- docker run -it -d -p 5000:5000 max-review-text-generator
-- sleep 10
+  - docker build -t max-review-text-generator .
+  - docker run -it -d --rm -p 5000:5000 max-review-text-generator
+  - sleep 30
 before_script:
-- pip install pytest requests
+  - pip install pytest requests
 script:
-- pytest tests/test.py
+  - pytest tests/test.py

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,7 @@ COPY requirements.txt /workspace
 RUN pip install -r requirements.txt
 
 COPY . /workspace
+RUN md5sum -c md5sums.txt # check file integrity
 
 EXPOSE 5000
 

--- a/api/model.py
+++ b/api/model.py
@@ -1,6 +1,5 @@
 from flask_restplus import Namespace, Resource, fields
 from flask import request
-
 from config import MODEL_META_DATA, DEFAULT_CHARS
 from core.backend import ModelWrapper
 
@@ -13,12 +12,13 @@ model_meta = api.model('ModelMetadata', {
     'license': fields.String(required=False, description='Model license')
 })
 
+
 @api.route('/metadata')
 class Model(Resource):
     @api.doc('get_metadata')
     @api.marshal_with(model_meta)
     def get(self):
-        '''Return the metadata associated with the model'''
+        """Return the metadata associated with the model"""
         return MODEL_META_DATA
 
 
@@ -33,10 +33,6 @@ model_prediction = api.model('ModelPrediction', {
     'full_text': fields.String(required=False, description='Seed text followed by generated text')
 })
 
-predict_response = api.model('ModelPredictResponse', {
-    'status': fields.String(required=True, description='Response status message'),
-    'prediction': fields.Nested(model_prediction, description='Model prediction')
-})
 
 @api.route('/predict')
 class Predict(Resource):
@@ -45,9 +41,8 @@ class Predict(Resource):
 
     @api.doc('predict')
     @api.expect(model_input)
-    @api.marshal_with(predict_response)
     def post(self):
-        '''Make a prediction given input data'''
+        """Make a prediction given input data"""
         result = {'status': 'error'}
 
         j = request.get_json()

--- a/md5sums.txt
+++ b/md5sums.txt
@@ -1,0 +1,1 @@
+80e9e515ed85cbe1ad03d6a449f4f7c2  assets/generative_lang_model.h5

--- a/tests/test.py
+++ b/tests/test.py
@@ -2,7 +2,34 @@ import pytest
 import requests
 
 
-def test_response():
+def test_swagger():
+
+    model_endpoint = 'http://localhost:5000/swagger.json'
+
+    r = requests.get(url=model_endpoint)
+    assert r.status_code == 200
+    assert r.headers['Content-Type'] == 'application/json'
+
+    json = r.json()
+    assert 'swagger' in json
+    assert json.get('info') and json.get('info').get('title') == 'Model Asset Exchange Server'
+
+
+def test_metadata():
+
+    model_endpoint = 'http://localhost:5000/model/metadata'
+
+    r = requests.get(url=model_endpoint)
+    assert r.status_code == 200
+
+    metadata = r.json()
+    assert metadata['id'] == 'generative-language-model-keras'
+    assert metadata['name'] == 'Generative Language Model Keras'
+    assert metadata['description'] == 'Generative Language Model in Keras trained on Yelp reviews'
+    assert metadata['license'] == 'Apache2'
+
+
+def test_predict():
     seed_text = "went there for dinner on a friday night and i have to say i'm impressed by the quality of the food "
     chars = 20
     model_endpoint = 'http://localhost:5000/model/predict'


### PR DESCRIPTION
- Removed `predict_response()` from `api/model.py` (closes #12)
- Added test for other model endpoints
- Improved `.travis.yml` spacing
- Increased Travis-CI sleep time to `30`
- Added `--rm` flag to Traivs to keep our internal Jenkins server cleaner
- Verify downloaded files MD5 hashes